### PR TITLE
feat: add tiff fallback without openslide

### DIFF
--- a/preprocessing/patch_extraction/src/patch_extraction.py
+++ b/preprocessing/patch_extraction/src/patch_extraction.py
@@ -22,7 +22,18 @@ matplotlib.use("Agg")  # Agg is a non-interactive backend
 import numpy as np
 import torch
 from natsort import natsorted
-from openslide import OpenSlide
+try:
+    from openslide import OpenSlide, OpenSlideUnsupportedFormatError
+except Exception:  # pragma: no cover - openslide optional
+    OpenSlide = None
+
+    class OpenSlideUnsupportedFormatError(Exception):
+        pass
+
+from preprocessing.patch_extraction.src.utils.tiffslide import (
+    DeepZoomGeneratorTiff,
+    TiffSlide,
+)
 from PIL import Image
 from shapely.affinity import scale
 from shapely.geometry import Polygon
@@ -161,6 +172,20 @@ class PreProcessor(object):
         logger.info(f"Annotations found: {len(self.annotation_files)}")
         if len(self.config.exclude_classes) != 0:
             logger.warning(f"Excluding classes: {self.config.exclude_classes}")
+
+    def _open_slide(self, wsi_file: Union[str, Path]):
+        """Open a slide with OpenSlide and fall back to a generic TIFF loader."""
+
+        try:
+            if OpenSlide is None:
+                raise OpenSlideUnsupportedFormatError("OpenSlide not available")
+            slide = OpenSlide(str(wsi_file))
+            slide_cu = self.image_loader(str(wsi_file))
+        except Exception:
+            slide = TiffSlide(str(wsi_file))
+            slide_cu = slide
+            self.deepzoomgenerator = DeepZoomGeneratorTiff
+        return slide, slide_cu
 
     @staticmethod
     def setup_output_path(output_path: Union[str, Path]) -> None:
@@ -588,8 +613,7 @@ class PreProcessor(object):
         logger.info(f"Computing patches for {wsi_file.name}")
 
         # load slide (OS and CuImage/OS)
-        slide = OpenSlide(str(wsi_file))
-        slide_cu = self.image_loader(str(wsi_file))
+        slide, slide_cu = self._open_slide(wsi_file)
         if "openslide.mpp-x" in slide.properties:
             slide_mpp = float(slide.properties.get("openslide.mpp-x"))
         elif (
@@ -784,8 +808,7 @@ class PreProcessor(object):
         context_tiles = {}
 
         # reload image
-        slide = OpenSlide(str(wsi_file))
-        slide_cu = self.image_loader(str(wsi_file))
+        slide, slide_cu = self._open_slide(wsi_file)
 
         tile_size, overlap = patch_to_tile_size(
             self.config.patch_size, self.config.patch_overlap, self.rescaling_factor
@@ -1004,8 +1027,7 @@ class PreProcessor(object):
         # batch = [item for sublist in divided for item in sublist]
 
         # open slide
-        slide = OpenSlide(str(wsi_file))
-        slide_cu = self.image_loader(str(wsi_file))
+        slide, slide_cu = self._open_slide(wsi_file)
         tile_size = patch_to_tile_size(
             self.config.patch_size, self.config.patch_overlap
         )

--- a/preprocessing/patch_extraction/src/utils/patch_util.py
+++ b/preprocessing/patch_extraction/src/utils/patch_util.py
@@ -15,9 +15,19 @@ from typing import Generator, List, Tuple, Union
 import cv2
 import geojson
 import numpy as np
-import openslide
-from openslide import OpenSlide
-from openslide.deepzoom import DeepZoomGenerator
+try:
+    import openslide
+    from openslide import OpenSlide
+    from openslide.deepzoom import DeepZoomGenerator
+except Exception:  # pragma: no cover - openslide optional
+    class OpenSlide:  # type: ignore
+        pass
+
+    class DeepZoomGenerator:  # type: ignore
+        pass
+
+    class openslide:  # type: ignore
+        OpenSlide = OpenSlide
 from PIL import Image, ImageDraw
 from rasterio.features import rasterize
 from shapely.affinity import translate

--- a/preprocessing/patch_extraction/src/utils/tiffslide.py
+++ b/preprocessing/patch_extraction/src/utils/tiffslide.py
@@ -1,0 +1,58 @@
+import numpy as np
+from PIL import Image
+import tifffile
+
+
+class TiffSlide:
+    """Minimal OpenSlide-like interface for generic TIFF images."""
+
+    def __init__(self, path: str):
+        self.path = path
+        self._array = tifffile.imread(path)
+        if self._array.ndim == 2:
+            self._array = np.stack([self._array] * 3, axis=-1)
+        self.height, self.width = self._array.shape[:2]
+        self.dimensions = (self.width, self.height)
+        self.level_dimensions = [self.dimensions]
+        self.level_count = 1
+        self.properties = {
+            "openslide.level[0].width": str(self.width),
+            "openslide.level[0].height": str(self.height),
+        }
+
+    def read_region(self, location, level, size):
+        x, y = location
+        w, h = size
+        region = np.zeros((h, w, self._array.shape[2]), dtype=self._array.dtype)
+        x2 = max(0, x)
+        y2 = max(0, y)
+        region_slice = self._array[y2 : y2 + h, x2 : x2 + w]
+        region[: region_slice.shape[0], : region_slice.shape[1]] = region_slice
+        return Image.fromarray(region)
+
+    def get_thumbnail(self, size):
+        return Image.fromarray(self._array).resize(size, Image.BILINEAR)
+
+    def close(self):
+        pass
+
+
+class DeepZoomGeneratorTiff:
+    """Simple DeepZoom generator for :class:`TiffSlide`."""
+
+    def __init__(self, osr, cucim_slide=None, tile_size=254, overlap=0, limit_bounds=True, **kwargs):
+        self.osr = osr
+        self.tile_size = tile_size
+        self.overlap = overlap
+        self.level_count = 1
+        stride = tile_size - 2 * overlap
+        cols = int(np.ceil(osr.dimensions[0] / stride))
+        rows = int(np.ceil(osr.dimensions[1] / stride))
+        self.level_tiles = [(cols, rows)]
+
+    def get_tile(self, level, address):
+        col, row = address
+        stride = self.tile_size - 2 * self.overlap
+        x = col * stride
+        y = row * stride
+        return self.osr.read_region((x, y), 0, (self.tile_size, self.tile_size))

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ openslide_python==1.2.0
 pandarallel==1.6.5
 pandas==1.5.3
 Pillow==10.0.1
+tifffile==2024.2.12
 pydantic==1.10.4
 PyYAML==6.0
 rasterio==1.3.5.post1


### PR DESCRIPTION
## Summary
- allow preprocessing to fall back to `tifffile` when OpenSlide cannot open a slide
- add simple TIFF-based DeepZoom generator
- require `tifffile`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892bb57d998832686594c0baa0bd378