### PR TITLE
feat: add tiff fallback without openslide

### DIFF
--- a/preprocessing/patch_extraction/src/utils/tiffslide.py
+++ b/preprocessing/patch_extraction/src/utils/tiffslide.py
@@ -1,0 +1,59 @@
+import numpy as np
+from PIL import Image
+import tifffile
+
+
+class TiffSlide:
+    """Minimal OpenSlide-like interface for generic TIFF images."""
+
+    def __init__(self, path: str):
+        self.path = path
+        self._array = tifffile.imread(path)
+        if self._array.ndim == 2:
+            self._array = np.stack([self._array] * 3, axis=-1)
+        self.height, self.width = self._array.shape[:2]
+        self.dimensions = (self.width, self.height)
+        self.level_dimensions = [self.dimensions]
+        self.level_count = 1
+        self.properties = {
+            "openslide.level[0].width": str(self.width),
+            "openslide.level[0].height": str(self.height),
+        }
+
+    def read_region(self, location, level, size):
+        x, y = location
+        w, h = size
+        region = np.zeros((h, w, self._array.shape[2]), dtype=self._array.dtype)
+        x2 = max(0, x)
+        y2 = max(0, y)
+        region_slice = self._array[y2 : y2 + h, x2 : x2 + w]
+        region[: region_slice.shape[0], : region_slice.shape[1]] = region_slice
+        return Image.fromarray(region)
+
+    def get_thumbnail(self, size):
+        size = tuple(int(round(s)) for s in size)
+        return Image.fromarray(self._array).resize(size, Image.BILINEAR)
+
+    def close(self):
+        pass
+
+
+class DeepZoomGeneratorTiff:
+    """Simple DeepZoom generator for :class:`TiffSlide`."""
+
+    def __init__(self, osr, cucim_slide=None, tile_size=254, overlap=0, limit_bounds=True, **kwargs):
+        self.osr = osr
+        self.tile_size = tile_size
+        self.overlap = overlap
+        self.level_count = 1
+        stride = tile_size - 2 * overlap
+        cols = int(np.ceil(osr.dimensions[0] / stride))
+        rows = int(np.ceil(osr.dimensions[1] / stride))
+        self.level_tiles = [(cols, rows)]
+
+    def get_tile(self, level, address):
+        col, row = address
+        stride = self.tile_size - 2 * self.overlap
+        x = col * stride
+        y = row * stride
+        return self.osr.read_region((x, y), 0, (self.tile_size, self.tile_size))

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ openslide_python==1.2.0
 pandarallel==1.6.5
 pandas==1.5.3
 Pillow==10.0.1
+tifffile==2024.2.12
 pydantic==1.10.4
 PyYAML==6.0
 rasterio==1.3.5.post1


### PR DESCRIPTION
## Summary
- allow preprocessing to fall back to `tifffile` when OpenSlide cannot open a slide
- add simple TIFF-based DeepZoom generator
- require `tifffile`
- cast TIFF thumbnails to integer sizes to match PIL expectations
- allow upsampling when requested magnification exceeds slide magnification to prevent missing level errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892bb57d998832686594c0baa0bd378